### PR TITLE
Fetch `TabIcons` from remote source

### DIFF
--- a/android/app/src/main/java/com/reactnativenavigation/params/parsers/TabIconParser.java
+++ b/android/app/src/main/java/com/reactnativenavigation/params/parsers/TabIconParser.java
@@ -1,9 +1,19 @@
 package com.reactnativenavigation.params.parsers;
 
+import android.graphics.Bitmap;
+import android.graphics.BitmapFactory;
+import android.graphics.drawable.BitmapDrawable;
 import android.graphics.drawable.Drawable;
 import android.os.Bundle;
+import android.util.Log;
 
+import com.reactnativenavigation.BuildConfig;
 import com.reactnativenavigation.react.ImageLoader;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.HttpURLConnection;
+import java.net.URL;
 
 class TabIconParser extends Parser {
 
@@ -16,8 +26,36 @@ class TabIconParser extends Parser {
     public Drawable parse() {
         Drawable tabIcon = null;
         if (hasKey(params, "icon")) {
-            tabIcon = ImageLoader.loadImage(params.getString("icon"));
+            String tabUrl = params.getString("icon");
+
+            if(!BuildConfig.DEBUG && isRemoteImage(tabUrl)) {
+                try {
+                    tabIcon = drawableFromUrl(tabUrl);
+                } catch(IOException err) {
+                    Log.w("TabIcon", "Exception while fetching for image:" + err.getMessage());
+                    tabIcon = null;
+                }
+
+            } else {
+                tabIcon = ImageLoader.loadImage(tabUrl);
+            }
+
         }
         return tabIcon;
+    }
+
+    private boolean isRemoteImage(String url) {
+        return  url.contains("http");
+    }
+
+    private Drawable drawableFromUrl(String url) throws IOException {
+        Bitmap x;
+
+        HttpURLConnection connection = (HttpURLConnection) new URL(url).openConnection();
+        connection.connect();
+        InputStream input = connection.getInputStream();
+
+        x = BitmapFactory.decodeStream(input);
+        return new BitmapDrawable(null, x);
     }
 }


### PR DESCRIPTION
Normally, tab icons wouldn't be set, if pointed to remote uri in release mode. This PR fixes it